### PR TITLE
Add CodeXEmbedModel2B support

### DIFF
--- a/docs/source/models/supported_models.md
+++ b/docs/source/models/supported_models.md
@@ -718,8 +718,12 @@ Specified using `--task embed`.
 - * `NomicBertModel`
   * Nomic BERT
   * `nomic-ai/nomic-embed-text-v1`, `nomic-ai/nomic-embed-text-v2-moe`, `Snowflake/snowflake-arctic-embed-m-long`, etc.
-  * ︎
-  * ︎
+  *
+- * `CodeXEmbedModel2B`
+  * CodeXEmbed
+  * `Salesforce/SFR-Embedding-Code-2B_R`
+  *
+  *
 - * `LlamaModel`, `LlamaForCausalLM`, `MistralModel`, etc.
   * Llama-based
   * `intfloat/e5-mistral-7b-instruct`, etc.

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -269,6 +269,10 @@ _EMBEDDING_EXAMPLE_MODELS = {
                                 trust_remote_code=True),
     "NomicBertModel": _HfExamplesInfo("Snowflake/snowflake-arctic-embed-m-long",  # noqa: E501
                                                trust_remote_code=True),
+    "CodeXEmbedModel2B": _HfExamplesInfo(
+        "Salesforce/SFR-Embedding-Code-2B_R",
+        trust_remote_code=True,
+    ),
     "Qwen2Model": _HfExamplesInfo("ssmits/Qwen2-7B-Instruct-embed-base"),
     "Qwen2ForRewardModel": _HfExamplesInfo("Qwen/Qwen2.5-Math-RM-72B"),
     "Qwen2ForProcessRewardModel": _HfExamplesInfo("Qwen/Qwen2.5-Math-PRM-7B"),

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -140,6 +140,7 @@ _EMBEDDING_MODELS = {
     "MistralModel": ("llama", "LlamaForCausalLM"),
     "ModernBertModel": ("modernbert", "ModernBertModel"),
     "NomicBertModel": ("bert_with_rope", "NomicBertModel"),
+    "CodeXEmbedModel2B": ("transformers", "TransformersForCausalLM"),
     "Phi3ForCausalLM": ("phi3", "Phi3ForCausalLM"),
     "Qwen2Model": ("qwen2", "Qwen2EmbeddingModel"),
     "Qwen2ForCausalLM": ("qwen2", "Qwen2ForCausalLM"),


### PR DESCRIPTION
## Summary
- register `CodeXEmbedModel2B` architecture
- add SFR embedding model example
- document the new embedding model

## Testing
- `pre-commit` *(fails: command not found)*